### PR TITLE
Update video audio types mp3,mkv,mp4,webm

### DIFF
--- a/src/main/resources/META-INF/mimetypes.default
+++ b/src/main/resources/META-INF/mimetypes.default
@@ -20,10 +20,10 @@ audio/x-aifc		aifc
 audio/x-aiff            aif aiff
 audio/x-mpeg		mpeg mpg
 audio/x-wav             wav
-audio/mp3             mp3
+audio/mp3             mp3 MP3
 video/mpeg		mpeg mpg mpe
 video/quicktime		qt mov
-video/x-msvideo		avi
-video/mkv		mkv
-video/mp4		mp4
-video/webm		webm
+video/x-msvideo		avi AVI
+video/mkv		mkv MKV
+video/mp4		mp4 MP4
+video/webm		webm WEBM

--- a/src/main/resources/META-INF/mimetypes.default
+++ b/src/main/resources/META-INF/mimetypes.default
@@ -20,6 +20,10 @@ audio/x-aifc		aifc
 audio/x-aiff            aif aiff
 audio/x-mpeg		mpeg mpg
 audio/x-wav             wav
+audio/mp3             mp3
 video/mpeg		mpeg mpg mpe
 video/quicktime		qt mov
 video/x-msvideo		avi
+video/mkv		mkv
+video/mp4		mp4
+video/webm		webm

--- a/src/main/resources/META-INF/mimetypes.default
+++ b/src/main/resources/META-INF/mimetypes.default
@@ -27,3 +27,5 @@ video/x-msvideo		avi AVI
 video/mkv		mkv MKV
 video/mp4		mp4 MP4
 video/webm		webm WEBM
+video/flv		flv FLV
+video/x-flv		x-flv X-FLV


### PR DESCRIPTION
Getting results :
application/octet-stream
application/octet-stream
application/octet-stream
application/octet-stream

for all of my codes:
System.out.println(MimetypesFileTypeMap.getDefaultFileTypeMap().getContentType("/usr/lo.cal/myfile.mp3"));
System.out.println(MimetypesFileTypeMap.getDefaultFileTypeMap().getContentType("/usr/lo.cal/myfile.mkv"));
System.out.println(MimetypesFileTypeMap.getDefaultFileTypeMap().getContentType("/usr/lo.cal/myfile.mp4"));
System.out.println(MimetypesFileTypeMap.getDefaultFileTypeMap().getContentType("/usr/lo.cal/myfile.webm"));
